### PR TITLE
Filter markdown in navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,5 @@ The repository currently includes a small backend written in Python. Run it with
 python main.py --debug
 ```
 The script ensures required directories exist (`prompts`, `vars`, and `prompt-vars`) and then launches the GUI.
+
+Only Markdown files within the `prompts` directory appear in the navigation tree. File extensions are stripped so, for example, "Hunters.md" is shown as "Hunters".

--- a/skellaprompter/gui.py
+++ b/skellaprompter/gui.py
@@ -110,11 +110,11 @@ class MainWindow(QMainWindow):
         """Rebuild the navigation tree from the prompts directory."""
         self.prompt_tree.clear()
         prompts_root = self.base_path / "prompts"
-        for path in sorted(prompts_root.rglob("*")):
+        for path in sorted(prompts_root.rglob("*.md")):
             if path.is_file():
                 rel = path.relative_to(prompts_root)
                 parent = self._ensure_parents(rel.parts[:-1])
-                item = QTreeWidgetItem([rel.name])
+                item = QTreeWidgetItem([rel.stem])
                 item.setData(0, Qt.UserRole, path)
                 parent.addChild(item)
 


### PR DESCRIPTION
## Summary
- restrict GUI navigation tree to Markdown files
- strip `.md` extension from file names in the tree
- document filtering behavior in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685995fcc7308325a873ab21af41874e