### PR TITLE
Add default values to variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,23 @@ python main.py --debug
 The script ensures required directories exist (`prompts`, `vars`, and `prompt-vars`) and then launches the GUI.
 
 Only Markdown files within the `prompts` directory appear in the navigation tree. File extensions are stripped so, for example, "Hunters.md" is shown as "Hunters".
+
+## Variable syntax
+
+Template variables are marked using one of four delimiters:
+
+- `{{name}}` for global variables
+- `<<name>>` for prompt-local variables
+- `[[name]]` for short free-form text
+- `[[[name]]]` for long free-form text
+
+You can specify a default value after the variable name using a pipe (`|`).
+For example:
+
+```
+{{Character|John}}
+<<Location|Dungeon>>
+```
+
+When the template loads, these defaults pre-fill the corresponding fields even
+if they are not listed in the YAML options file.


### PR DESCRIPTION
## Summary
- add optional default field in variable markup
- populate UI widgets with default values and return them if unchanged
- document variable syntax with default values

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6859975e3fdc83259b7353a1cd05ecbc