### PR TITLE
Enable editing and saving prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ The script ensures required directories exist (`prompts`, `vars`, and `prompt-va
 
 Only Markdown files within the `prompts` directory appear in the navigation tree. File extensions are stripped so, for example, "Hunters.md" is shown as "Hunters".
 
+You can edit a template directly from the **Template** tab. Use **File → Save**
+to write the changes to disk. Saving automatically refreshes the list of
+variables extracted from the template.
+
 ## Variable syntax
 
 Template variables are marked using one of four delimiters:

--- a/skellaprompter/gui.py
+++ b/skellaprompter/gui.py
@@ -62,7 +62,7 @@ class MainWindow(QMainWindow):
         self.prompt_edit = QPlainTextEdit()
         self.prompt_edit.setReadOnly(True)
         self.template_edit = QPlainTextEdit()
-        self.template_edit.setReadOnly(True)
+        self.template_edit.setReadOnly(False)
 
         self.tabs = QTabWidget()
         self.tabs.addTab(self.prompt_edit, "Prompt")
@@ -104,6 +104,8 @@ class MainWindow(QMainWindow):
 
     def build_menu(self) -> None:
         file_menu = self.menuBar().addMenu("File")
+        save_action = file_menu.addAction("Save")
+        save_action.triggered.connect(self.save_prompt)
         resync_action = file_menu.addAction("Resync")
         resync_action.triggered.connect(self.resync)
         file_menu.addSeparator()
@@ -293,6 +295,18 @@ class MainWindow(QMainWindow):
             text = var.widget.toPlainText()
             return text if text else (var.default or "")
         return ""
+
+    def save_prompt(self) -> None:
+        """Save the template to disk and resync variables."""
+        if not self.template_path:
+            return
+        text = self.template_edit.toPlainText()
+        self.template_path.write_text(text, encoding="utf-8")
+        self.template_text = text
+        self.resync()
+        self.build_variables()
+        self.render_prompt()
+        self.statusBar().showMessage("Saved", 2000)
 
     def copy_prompt(self) -> None:
         text = self.prompt_edit.toPlainText()


### PR DESCRIPTION
## Summary
- allow editing prompt templates in the GUI
- add Save action that writes the template and refreshes variable list
- document the Save feature in the README

## Testing
- `python -m pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6859a107af248325a99749710a018885